### PR TITLE
Now properly displays the correct number of characters requested

### DIFF
--- a/Develop/script.js
+++ b/Develop/script.js
@@ -97,6 +97,11 @@ function generatePassword() {
     possiblecharacters = possiblecharacters.concat(UpperCaseC);
     guaranteedcharacters.push(Random(UpperCaseC));
   }
+
+  for (var i = 0; i < options.length; i++) {
+    var possiblecharacters = Random(possiblecharacters);
+    result.push(possiblecharacters);
+  }
   
   for (var i = 0; i < guaranteedcharacters.length; i++) {
     result [i] = guaranteedcharacters[i];


### PR DESCRIPTION
Previously everything was working except when it asked you how many characters you wanted in your password it would only display around 4. I have now fixed this issue.